### PR TITLE
Fixed whitespace warning in header file.

### DIFF
--- a/Spotify.framework/Versions/A/Headers/SPTRequest.h
+++ b/Spotify.framework/Versions/A/Headers/SPTRequest.h
@@ -107,7 +107,7 @@ FOUNDATION_EXPORT NSString * const SPTMarketFromToken;
  `SPTAuthPlaylistReadScope` or `SPTAuthPlaylistReadPrivateScope` scope as necessary.
  @param block The block to be called when the operation is complete. The block will pass an `SPTPlaylistSnapshot` object on success, otherwise an error.
  */
-+(void)starredListForUserInSession:(SPTSession *)session callback:(SPTRequestCallback)block DEPRECATED_ATTRIBUTE ;
++(void)starredListForUserInSession:(SPTSession *)session callback:(SPTRequestCallback)block DEPRECATED_ATTRIBUTE;
 
 ///----------------------------
 /// @name User Information


### PR DESCRIPTION
This was bugging me when I started trying out the framework.