### PR TITLE
docs(readme): correct broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Spotify iOS SDK is a set of lightweight objects that connect with the Spotif
 
 [Components](#components)
 
-[How Do Remote Calls Work?](#how-do-remote-calls-work)
+[How Do App Remote Calls Work?](#how-do-app-remote-calls-work)
 
 [Terms of Use](#terms-of-use)
 


### PR DESCRIPTION
The link to section `How do App Remote calls work` was broken.
This change makes the link correct again.