### PR TITLE
Fixes way how ContentItemCell is checked of not being reused.

### DIFF
--- a/DemoProjects/NowPlayingView/NowPlayingView/ContentCollectionViewController.swift
+++ b/DemoProjects/NowPlayingView/NowPlayingView/ContentCollectionViewController.swift
@@ -65,10 +65,9 @@ class ContentCollectionViewController : UICollectionViewController, UICollection
 
         cell.imageView.image = nil
         appRemote.imageAPI?.fetchImage(forItem: item, with: scaledSizeForCell(cell)) { (image, error) in
-            // If the cell hasn't been reused
-            if cell.titleLabel.text == item.title {
-                cell.imageView?.image = image as? UIImage
-            }
+            guard let image = image as? UIImage, error == nil,
+                  let cell = collectionView.cellForItem(at: indexPath) as? ContentItemCell else { return }
+            cell.imageView?.image = image
         }
 
         return cell


### PR DESCRIPTION
Check of title for match as way to ensure cell wasn't reused is bad because there's no guaranty titles are unique.
UIKit gives method for such check.
If UICollectionView.cellForItem(at:) returns not nil - that is exactly cell which is needed. And returns nil if cell is not visible and there's no reason to update it.