### PR TITLE
present alerts on main UI thread to avoid runtime errors

### DIFF
--- a/DemoProjects/SPTLoginSampleAppSwift/SPTLoginSampleAppSwift.xcodeproj/project.pbxproj
+++ b/DemoProjects/SPTLoginSampleAppSwift/SPTLoginSampleAppSwift.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				DEVELOPMENT_TEAM = NGR89BBT5V;
 				INFOPLIST_FILE = SPTLoginSampleAppSwift/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -321,7 +321,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				DEVELOPMENT_TEAM = NGR89BBT5V;
 				INFOPLIST_FILE = SPTLoginSampleAppSwift/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/DemoProjects/SPTLoginSampleAppSwift/SPTLoginSampleAppSwift/ViewController.swift
+++ b/DemoProjects/SPTLoginSampleAppSwift/SPTLoginSampleAppSwift/ViewController.swift
@@ -198,11 +198,15 @@ class ViewController: UIViewController, SPTSessionManagerDelegate, SPTAppRemoteD
     // MARK: - SPTSessionManagerDelegate
 
     func sessionManager(manager: SPTSessionManager, didFailWith error: Error) {
-        presentAlertController(title: "Authorization Failed", message: error.localizedDescription, buttonTitle: "Bummer")
+        DispatchQueue.main.async {
+            self.presentAlertController(title: "Authorization Failed", message: error.localizedDescription, buttonTitle: "Bummer")
+        }
     }
 
     func sessionManager(manager: SPTSessionManager, didRenew session: SPTSession) {
-        presentAlertController(title: "Session Renewed", message: session.description, buttonTitle: "Sweet")
+        DispatchQueue.main.async {
+            self.presentAlertController(title: "Session Renewed", message: session.description, buttonTitle: "Sweet")
+        }
     }
 
     func sessionManager(manager: SPTSessionManager, didInitiate session: SPTSession) {


### PR DESCRIPTION
Prior version had runtime crashes when presenting alert controllers. This avoids these error.