### PR TITLE
Added state button in the Demo app

### DIFF
--- a/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp.xcodeproj/project.pbxproj
+++ b/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3518DFFB1F99674A00A5313C /* ConnectButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 3518DFFA1F99674A00A5313C /* ConnectButton.m */; };
 		3518DFFE1F99983F00A5313C /* ConnectView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3518DFFD1F99983F00A5313C /* ConnectView.m */; };
 		5413459A20D100AD00FD05F7 /* SpotifyiOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5413459920D100AD00FD05F7 /* SpotifyiOS.framework */; };
+		5D8A04B92350D51F00639CEE /* SpotifyiOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5413459920D100AD00FD05F7 /* SpotifyiOS.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +72,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5D8A04B92350D51F00639CEE /* SpotifyiOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -380,7 +382,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				DEVELOPMENT_TEAM = U8H2KJ7NX5;
 				INFOPLIST_FILE = SPTLoginSampleApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -396,7 +398,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				DEVELOPMENT_TEAM = U8H2KJ7NX5;
 				INFOPLIST_FILE = SPTLoginSampleApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -414,7 +416,7 @@
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				DEVELOPMENT_TEAM = U8H2KJ7NX5;
 				INFOPLIST_FILE = SPTLoginSampleAppUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -432,7 +434,7 @@
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2FNC3A47ZF;
+				DEVELOPMENT_TEAM = U8H2KJ7NX5;
 				INFOPLIST_FILE = SPTLoginSampleAppUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp/ConnectView.h
+++ b/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp/ConnectView.h
@@ -7,4 +7,6 @@
 
 @property (nonatomic) ConnectButton *connectButton;
 
+@property (nonatomic) ConnectButton *stateButton;
+
 @end

--- a/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp/ConnectView.m
+++ b/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp/ConnectView.m
@@ -28,6 +28,12 @@
         [label.centerXAnchor constraintEqualToAnchor:connectButton.centerXAnchor].active = YES;
         [label.bottomAnchor constraintEqualToAnchor:connectButton.topAnchor constant:-16.0].active = YES;
         [label sizeToFit];
+
+        ConnectButton *stateButton = [self buttonWithTitle:@"STATE"];
+        self.stateButton = stateButton;
+        [self addSubview:stateButton];
+        [stateButton.centerXAnchor constraintEqualToAnchor:self.centerXAnchor].active = YES;
+        [stateButton.centerYAnchor constraintEqualToAnchor:connectButton.bottomAnchor constant:50.0].active = YES;
     }
 
     return self;

--- a/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp/ViewController.h
+++ b/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp/ViewController.h
@@ -8,6 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) SPTSessionManager *sessionManager;
 
+@property (nonatomic) SPTAppRemote *appRemote;
+
 @end
 
 

--- a/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp/ViewController.m
+++ b/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp/ViewController.m
@@ -56,6 +56,14 @@ static NSString * const SpotifyRedirectURLString = @"spotify-login-sdk-test-app:
     }
 }
 
+- (void)didTapStateButton:(ConnectButton *)sender
+{
+    NSLog(@"-----------> didTapStateButton");
+    [[self.appRemote playerAPI] getPlayerState:^(id<SPTAppRemotePlayerState> state, NSError* error) {
+        NSLog(@"-----------> getPlayerState returned");
+    }];
+}
+
 #pragma mark - SPTSessionManagerDelegate
 
 - (void)sessionManager:(SPTSessionManager *)manager didInitiateSession:(SPTSession *)session
@@ -85,6 +93,7 @@ static NSString * const SpotifyRedirectURLString = @"spotify-login-sdk-test-app:
 {
     ConnectView *view = [ConnectView new];
     [view.connectButton addTarget:self action:@selector(didTapAuthButton:) forControlEvents:UIControlEventTouchUpInside];
+    [view.stateButton addTarget:self action:@selector(didTapStateButton:) forControlEvents:UIControlEventTouchUpInside];
     self.view = view;
 }
 


### PR DESCRIPTION
This state button calls `playerAPI getPlayerState`. It demonstrate that the callback never fires, or so I think.

The state button calls:
```

    NSLog(@"-----------> didTapStateButton");
    [[self.appRemote playerAPI] getPlayerState:^(id<SPTAppRemotePlayerState> state, NSError* error) {
        NSLog(@"-----------> getPlayerState returned");
    }];

```

I cannot see the second log message.

Further, in my app, I can call getPlayerState repeatedly and see it crash (too many callbacks in the stack).