### PR TITLE
fix: present alert controller on main thread

### DIFF
--- a/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp/ViewController.m
+++ b/DemoProjects/SPTLoginSampleApp/SPTLoginSampleApp/ViewController.m
@@ -60,23 +60,32 @@ static NSString * const SpotifyRedirectURLString = @"spotify-login-sdk-test-app:
 
 - (void)sessionManager:(SPTSessionManager *)manager didInitiateSession:(SPTSession *)session
 {
-    [self presentAlertControllerWithTitle:@"Authorization Succeeded"
-                                  message:session.description
-                              buttonTitle:@"Nice"];
+    dispatch_async(dispatch_get_main_queue(), ^{
+            [self presentAlertControllerWithTitle:@"Authorization Succeeded"
+                                      message:session.description
+                                  buttonTitle:@"Nice"];
+    });
+
 }
 
 - (void)sessionManager:(SPTSessionManager *)manager didFailWithError:(NSError *)error
 {
-    [self presentAlertControllerWithTitle:@"Authorization Failed"
-                                  message:error.description
-                              buttonTitle:@"Bummer"];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self presentAlertControllerWithTitle:@"Authorization Failed"
+                                      message:error.description
+                                  buttonTitle:@"Bummer"];
+    });
+
 }
 
 - (void)sessionManager:(SPTSessionManager *)manager didRenewSession:(SPTSession *)session
 {
-    [self presentAlertControllerWithTitle:@"Session Renewed"
-                                  message:session.description
-                              buttonTitle:@"Sweet"];
+    dispatch_async(dispatch_get_main_queue(), ^{
+            [self presentAlertControllerWithTitle:@"Session Renewed"
+                                      message:session.description
+                                  buttonTitle:@"Sweet"];
+
+    });
 }
 
 #pragma mark - Set up view


### PR DESCRIPTION
I was playing around with the objective-c example this week and the demo app kept crashing. Turns out the alert view controllers were not being presented on the main thread. I wrapped each of the presentation calls in dispatch_async to make sure those UI updates happen on the main queue! 