### PR TITLE
feat: add swift package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "SpotifyiOS",
+    platforms: [
+        .iOS(.v9)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "SpotifyiOS",
+            targets: ["SpotifyiOS"])
+    ],
+    dependencies: [],
+    targets: [
+        .binaryTarget(
+            name: "SpotifyiOS",
+            path: "SpotifyiOS.xcframework"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Follow these steps to make sure you are prepared to start coding.
 
 ### Add Dependencies
 
-1. Add the `SpotifyiOS.framework` or `SpotifyiOS.xcframework` to your Xcode project.
+1. Add the SpotifyiOS package to your project. You can either do this through Swift Package Manager (SPM), or by adding `SpotifyiOS.framework` or `SpotifyiOS.xcframework` to your Xcode project directly.
 
     ![Import SpotifyiOS.framework](img/import_sdk.png)
 


### PR DESCRIPTION
Adding this Swift Package manifest file lets your package be consumed via Swift Package Manager (SPM) for use in Xcode or other swift package projects. Since you already have GitHub releases with compatible tag names, once this file is merged anyone will be able to consume your binary xcframework through SPM without the hassle of having to drag and drop the framework or xcframework file directly into their project.